### PR TITLE
forced version of httmultiparty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "fakeweb", "~> 1.3.0"
-gem "httmultiparty", "~> 0.3.8"
+gem "httmultiparty", "0.3.8"
 gem "rake", "~> 0.9.2.2"
 
 # Specify your gem's dependencies in phaxio.gemspec

--- a/phaxio.gemspec
+++ b/phaxio.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Phaxio::VERSION
 
-  gem.add_runtime_dependency      "httmultiparty", "~> 0.3.8"
+  gem.add_runtime_dependency      "httmultiparty", "0.3.8"
   gem.add_development_dependency  "fakeweb",       "~> 1.3.0"
   gem.add_development_dependency  "rake",          "~> 0.9.2.2"
 end


### PR DESCRIPTION
Need to force the version of httmultiparty.  There's a bug in the latest patch release
