### PR TITLE
Created a new 'tmpname' method in 'client.rb' to fix Ruby v2.5.0+'s o…

### DIFF
--- a/lib/phaxio/client.rb
+++ b/lib/phaxio/client.rb
@@ -55,10 +55,7 @@ module Phaxio
           body = JSON.parse(response.body).with_indifferent_access
         else
           extension = MimeTypeHelper.extension_for_mimetype content_type
-          filename = File.join(
-            Dir.tmpdir,
-            Dir::Tmpname.make_tmpname('phaxio-', "download.#{extension}")
-          )
+          filename = File.join Dir.tmpdir, tmpname(extension)
           File.open(filename, 'wb') { |file| file.write response.body }
           body = {'success' => response.success?, 'data' => File.open(filename, 'rb')}
         end
@@ -91,6 +88,11 @@ module Phaxio
             raise Error::GeneralError, "#{status}: #{message}"
           end
         end
+      end
+
+      def tmpname(extension)
+      	t = Time.now.strftime("%Y%m%d")
+      	"phaxio-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}-download.#{extension}"
       end
 
       def post endpoint, params = {}

--- a/lib/phaxio/client.rb
+++ b/lib/phaxio/client.rb
@@ -91,8 +91,8 @@ module Phaxio
       end
 
       def tmpname(extension)
-      	t = Time.now.strftime("%Y%m%d")
-      	"phaxio-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}-download.#{extension}"
+        t = Time.now.strftime("%Y%m%d")
+        "phaxio-#{t}-#{$$}-#{rand(0x100000000).to_s(36)}-download.#{extension}"
       end
 
       def post endpoint, params = {}


### PR DESCRIPTION
Added a 'tmpname' method to /lib/phaxio/client.rb that mimics the 'make_tmpname' method that was removed in v2.5 based on the link below.

https://github.com/rails/rails/pull/31462/files

Creates results that look similar to '#<File:/tmp/phaxio-20180913-29538-1x6vefc-download.pdf>'.