### PR TITLE
Update gemspec to support faraday >= 1.0.1

### DIFF
--- a/phaxio.gemspec
+++ b/phaxio.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.required_ruby_version = '>= 2.0'
-  gem.add_dependency 'faraday', '~> 0.10'
+  gem.add_dependency 'faraday', '~> 0.10', '>= 1.0.1'
   gem.add_dependency 'mime-types', '~> 3.0'
   gem.add_dependency 'activesupport'
 end


### PR DESCRIPTION
Faraday was updated to 1.0.0 last year- allow newer versions to be supported.