### PR TITLE
Relax Faraday dependency to a range of versions

### DIFF
--- a/phaxio.gemspec
+++ b/phaxio.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.licenses      = ['MIT']
 
   gem.required_ruby_version = '>= 2.0'
-  gem.add_dependency 'faraday', '~> 0.10'
+  gem.add_dependency 'faraday', '>= 0.10', '< 2.0'
   gem.add_dependency 'mime-types', '~> 3.0'
   gem.add_dependency 'activesupport'
 end


### PR DESCRIPTION
Faraday was updated to version `1.0.0`. Currently, `phaxio-ruby` requires version `~> 0.10`. Unfortunately, this conflicts with many popular gems (one example being `sentry-ruby`) that require at least `1.0.0`. In general, Faraday is a very popular gem, so it makes sense to relax the dependency as much as possible.

This PR relaxes the Faraday version to allow both `0.10.x` and `1.x.y`.

Note that there is already [another PR](https://github.com/phaxio/phaxio-ruby/pull/29) that does something similar, but I believe that the present one introduces a better requirement: the other PR requires `~> 0.10, >= 1.0.1`, which would not include 1.0.0, nor `0.11`, but would include for example a future `2.0.0` version, which might include breaking changes. This PR instead restricts the semantic version to the ones known to work, namely anything from `0.10` to `1.x.y` included, but no more.