### PR TITLE
Add Spec for Webhook Signature Validation with Files

### DIFF
--- a/spec/resources/webhook_spec.rb
+++ b/spec/resources/webhook_spec.rb
@@ -30,5 +30,22 @@ RSpec.describe Webhook do
         expect(result).to eq(false)
       end
     end
+
+    context 'with files' do
+      let(:signature) { '1d2426c242a8c5de7eb1d9b662b7fda1d0b6edab' }
+      let(:params) { { test: true } }
+
+      let(:files) do
+        [
+          { name: 'file', tempfile: Tempfile.new('foo') },
+          { name: 'file', tempfile: Tempfile.new('bar') }
+        ]
+      end
+
+      it 'returns true' do
+        result = action
+        expect(result).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
I was implementing Phaxio request verification in an app and noticed no specs for verification when the request has a file.  After a while, I saw an example in the readme and an [open issue describing the process](https://github.com/phaxio/phaxio-ruby/issues/16), but the specs were the first place I looked.  I figure it's worth adding for anyone else who pops open the specs first.