### PR TITLE
Rewind Files After Reading the Files During Webhook Request Verification 

### DIFF
--- a/lib/phaxio/resources/webhook.rb
+++ b/lib/phaxio/resources/webhook.rb
@@ -57,7 +57,9 @@ module Phaxio
         end
 
         def generate_file_string(file)
-          file[:name] + DIGEST.hexdigest(file[:tempfile].read)
+          file_string = file[:name] + DIGEST.hexdigest(file[:tempfile].read)
+          file[:tempfile].rewind
+          file_string
         end
       end
     end

--- a/spec/resources/webhook_spec.rb
+++ b/spec/resources/webhook_spec.rb
@@ -30,5 +30,22 @@ RSpec.describe Webhook do
         expect(result).to eq(false)
       end
     end
+
+    context 'with files' do
+      let(:signature) { '1d2426c242a8c5de7eb1d9b662b7fda1d0b6edab' }
+      let(:params) { { test: true } }
+
+      let(:files) do
+        [
+          { name: 'file', tempfile: Tempfile.new('foo') },
+          { name: 'file', tempfile: Tempfile.new('bar') }
+        ]
+      end
+
+      it 'returns true' do
+        result = action
+        expect(result).to eq(true)
+      end
+    end
   end
 end

--- a/spec/resources/webhook_spec.rb
+++ b/spec/resources/webhook_spec.rb
@@ -35,16 +35,33 @@ RSpec.describe Webhook do
       let(:signature) { '1d2426c242a8c5de7eb1d9b662b7fda1d0b6edab' }
       let(:params) { { test: true } }
 
+      let(:file1) do
+        tempfile = Tempfile.new
+        tempfile.write("foo")
+        tempfile
+      end
+
+      let(:file2) do
+        tempfile = Tempfile.new
+        tempfile.write("bar")
+        tempfile
+      end
+
       let(:files) do
         [
-          { name: 'file', tempfile: Tempfile.new('foo') },
-          { name: 'file', tempfile: Tempfile.new('bar') }
+          { name: 'file', tempfile: file1 },
+          { name: 'file', tempfile: file2  }
         ]
       end
 
       it 'returns true' do
         result = action
         expect(result).to eq(true)
+      end
+
+      it 'rewinds the files' do
+        action
+        expect(files.all? { |f| f[:tempfile].pos.zero? }).to eq(true)
       end
     end
   end


### PR DESCRIPTION
After implementing Phaxio webhook request verification in an app, I ran into a bug where a downstream process was not able to read the contents of the tempfile because the tempfile had already been read during the signature verification process.

I attached a PR with specs to address that bug.

This supersede https://github.com/phaxio/phaxio-ruby/pull/50